### PR TITLE
chore: add auto-project workflow

### DIFF
--- a/.github/workflows/auto-project.yml
+++ b/.github/workflows/auto-project.yml
@@ -1,0 +1,13 @@
+name: Auto Add to Project
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  add-to-project:
+    uses: RequestNetwork/.github/.github/workflows/add-to-project.yml@main
+    secrets:
+      PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}


### PR DESCRIPTION
Adds workflow to automatically add issues and PRs to the [project board](https://github.com/orgs/RequestNetwork/projects/3).

- Issues: Added when opened
- PRs without linked issues: Added when opened
- PRs with linked issues: Not added (the linked issue is tracked instead)

Uses the reusable workflow from [RequestNetwork/.github](https://github.com/RequestNetwork/.github).

---
Closes RequestNetwork/public-issues#130